### PR TITLE
fixed categories display in article_catetags

### DIFF
--- a/layouts/partials/article_catetags.html
+++ b/layouts/partials/article_catetags.html
@@ -11,7 +11,7 @@
 {{ if not (eq (len .Params.categories) 0) }}
 <div class="article-categories">
   <span></span>
-  {{ range .Params.tags }}
+  {{ range .Params.categories }}
   <a class="article-category-link" href="/categories/{{ . | urlize }}">{{ . }}</a>
   {{ end }}
 </div>


### PR DESCRIPTION
文章底部显示“分类”的地方原来和左边“标签”内容一样，现已修复。
1. 搜索栏生成谷歌搜索地址时，在右边似乎多了个`}`号;
2. ”隐藏侧边栏“按钮链接到了主页，这样在文章页面里点这个按钮，会先隐藏侧边栏，然后跳回了主页;
3. 文章底部，在显示标签的后面应该要显示“分类”信息，然而它和标签信息一样;
4. 文章底部，QRcode按钮没效果;
5. 文章底部，”回到顶部“按钮似乎也链接到了主页;
6. 文章toc也链接到了主页。
这是我发现的一些Bugs，我自己试着看能不能修复。第一次给别人提交合并请求，如果有什么不对的地方，请多多包容一下我这个Github新人。
