### PR TITLE
Change Author => author for post param

### DIFF
--- a/layouts/partials/article_header.html
+++ b/layouts/partials/article_header.html
@@ -4,7 +4,7 @@
   </h1>
   <p class="article-author">By
     {{ if and (isset .Params "Author") (isset .Params "AuthorHomepage") }}
-      <a href="{{ .Params.AuthorHomepage }}" title="{{ .Params.Author }}">{{ .Params.Author }}</a>
+      <a href="{{ .Params.author_homepage }}" title="{{ .Params.author }}">{{ .Params.Author }}</a>
     {{ else }}
       <a href="{{ .Site.Params.AuthorHomepage }}" title="{{ .Site.Author.Name }}">{{ .Site.Author.Name }}</a>
     {{ end }}


### PR DESCRIPTION
It seems hugo cannot recognize upper case param in post. Change it to lower case.

似乎，Hugo在文章里面不支持大写的params名字。至少我设置AuthorHomepage和Author是不能触发这段code的。

只是修改了这一处，也许代码里还有其他地方有相同的问题。
