### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
   <meta name="twitter:title" content="{{ if ne .URL "/" }}{{ .Title }} - {{ end }}{{ .Site.Title }}" />{{ end }}
   {{ with .Description }}<meta name="twitter:description" content="{{ . }}" />{{ else }}
   <meta name="twitter:description" content="{{ .Site.Params.Description }}">{{ end }}
-  {{ if .RSSlink }}<link rel="alternate" href="{{ .Site.BaseURL }}feed.xml" title="{{ .Site.Title }}" type="application/rss+xml"/>{{ end }}
+  {{ if .RSSLink }}<link rel="alternate" href="{{ .Site.BaseURL }}feed.xml" title="{{ .Site.Title }}" type="application/rss+xml"/>{{ end }}
   <link rel="shortcut icon" href="{{ .Site.BaseURL }}img/favicon.ico"/>
   <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}apple-touch-icon.png" />
   <link rel="apple-touch-icon-precomposed" href="{{ .Site.BaseURL }}apple-touch-icon.png" />

--- a/layouts/partials/widgets/rss.html
+++ b/layouts/partials/widgets/rss.html
@@ -1,4 +1,4 @@
-{{ if .RSSlink }}
+{{ if .RSSLink }}
 <div class="rsspart">
   <a rel="nofollow" href="{{ .Site.BaseURL }}feed.xml" type="application/rss+xml" target="_blank">{{ .Site.Params.Strings.Rss }}</a>
 </div>


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.