### PR TITLE
Feature: add CreativeCommons icon support.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -33,6 +33,7 @@ pygmentsUseClasses = true
   DateFormat = "2006年01月02日"
   MonthFormat = "2006年01月"
   FancyBox = true
+  CreativeCommons = true
 
   [Params.GoogleAnalytics]
     ID = "UA-10147768-2"

--- a/layouts/partials/article_content.html
+++ b/layouts/partials/article_content.html
@@ -9,6 +9,15 @@
 		</div>
     {{ end }}
     {{ .Content }}
+    {{ if .Params.CreativeCommons }}
+    <div class="creative-commons">
+        <a rel="license"
+           href="https://creativecommons.org/licenses/by-sa/4.0/"><img
+           alt="知识共享许可协议" style="border-width:0"
+           src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" />
+        </a><br />
+    </div>
+    {{ end }}
 	</div>
   {{ partial "article_footer.html" . }}
 	</article>


### PR DESCRIPTION
Add a new Params options, allow users to choose whether to show a CreativeCommons icon at the articles bottom. by default is **BY-SA** license. Can change it by choosing a license code offer by [creativecommons.org](https://creativecommons.org/choose/?lang=en), and put that code into **article_content.html** file