### PR TITLE
Add detection for loading Disqus

### DIFF
--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -21,6 +21,12 @@ var duoshuoQuery = {short_name:"{{ .Site.Params.DuoShuo.ShortName }}"};
 <div id="disqus_thread"></div>
 </section>
 <script>
+  <!-- detect whether Disuqs can load -->
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '//disqus.com/next/config.json?' + new Date().getTime(), true);
+  xhr.timeout = 3000; // 3 seconds timeout limit, as so far
+
+  xhr.onload = function() { // set event handle function
 /**
 * RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
 * LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables
@@ -37,6 +43,12 @@ s.src = '//{{ .Site.Params.Disqus.ShortName }}.disqus.com/embed.js';
 s.setAttribute('data-timestamp', +new Date());
 (d.head || d.body).appendChild(s);
 })();
+}
+  xhr.ontimeout = function() {
+  <!-- cannot load Disqus, skip it. -->
+  return;
+}
+xhr.send(null);
 </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
 {{ end }}


### PR DESCRIPTION
In view of some location's special case, Disqus may not be loaded normally. As for that, we can add a little check by using **XMLHttpRequest** object at **comment.html** file, set up a time limit, by detecting a single file's loading status which Disqus needs. We can decide whether continuing loading the Disqus comment system or just skip it.